### PR TITLE
Re-add promptSuggestionEnabled: false — it was never a no-op, just remotely gated

### DIFF
--- a/setup/settings.json
+++ b/setup/settings.json
@@ -2,6 +2,7 @@
   "env": {
     "DISABLE_AUTOUPDATER": "1"
   },
+  "promptSuggestionEnabled": false,
   "statusLine": {
     "type": "command",
     "command": "~/.claude/scripts/context-bar.sh"


### PR DESCRIPTION
## Problem

57340fb dropped `promptSuggestionEnabled: false` from `setup/settings.json` as an "undocumented no-op". It turns out the setting always worked — it just had no visible effect at the time because the feature itself was held off by a remote GrowthBook gate (`tengu_chomp_inflection`, cached in `~/.claude.json` under `cachedGrowthBookFeatures`).

That gate has since flipped on, so prompt suggestions (a speculative next prompt prefilled in the input box, e.g. `❯ go ahead and update to 2.1.201`) now appear in containers again.

The CLI's decision chain, recovered from the 2.1.201 binary:

1. `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` env var (wins if set)
2. `tengu_chomp_inflection` remote gate (if off, suggestions are off regardless)
3. `promptSuggestionEnabled` setting — suggestions show unless explicitly `false`

The setting's own schema in the binary reads: *"When false, prompt suggestions are disabled. When absent or true, prompt suggestions are enabled."* Still undocumented in the official settings docs, but real.

## Demonstration

Verified on Claude Code 2.1.201 with an A/B test in tmux, same action-inviting prompt both times:

- **Without the setting:** ~20s after the reply, the input box prefilled `❯ set up a global gitignore with that command`
- **With `promptSuggestionEnabled: false`:** input box stayed empty across ~50s of stable-idle checks, even though the reply ended with an explicit offer (the strongest trigger shape)

## Change

Re-adds the one line to `setup/settings.json`, restoring the behavior originally introduced in 65e531c.