### PR TITLE
Bump claude-code-tips to v0.26.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash -s -- ${CLAUDE_CODE_VERSION}
 # === SETUP Claude Code ===
 
 # Install DX plugin and Playwright MCP server
-ARG CLAUDE_CODE_TIPS_VERSION=v0.26.21
+ARG CLAUDE_CODE_TIPS_VERSION=v0.26.26
 RUN claude plugin marketplace add https://github.com/ykdojo/claude-code-tips.git#${CLAUDE_CODE_TIPS_VERSION} && \
     claude plugin install dx@ykdojo && \
     claude mcp add playwright -- playwright-mcp --headless --browser chromium --no-sandbox


### PR DESCRIPTION
Bumps `CLAUDE_CODE_TIPS_VERSION` from v0.26.21 to v0.26.26.

The main plugin-relevant change in between is the reddit-fetch skill rework: direct curl to Reddit's `.json` endpoints now 403s essentially every time, so the skill leads with the DuckDuckGo-hop browser unlock instead. The remaining commits are tips content that doesn't affect the plugin at runtime.