### PR TITLE
Bump Claude Code to 2.1.219 and default to Opus 5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ After making changes, rebuild and test:
 
 This opens http://localhost:7681 in the browser. Verify:
 1. Claude Code launches automatically with bypass permissions
-2. Confirm it shows the correct model (Opus 4.8) and doesn't ask for login
+2. Confirm it shows the correct model (Opus 5) and doesn't ask for login
 3. Send a message and confirm it gets a response
 
 ## Multiple sessions

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=America/Los_Angeles
 ARG NODE_VERSION=24
 ARG PLAYWRIGHT_MCP_VERSION=0.0.62
-ARG CLAUDE_CODE_VERSION=2.1.201
+ARG CLAUDE_CODE_VERSION=2.1.219
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -112,7 +112,7 @@ RUN jq '. + {hasCompletedOnboarding: true, autoCompactEnabled: false}' /home/scl
 
 # Set default model (must be after plugin install which rewrites settings.json).
 # Without this, the Claude API account defaults to Sonnet, not Opus.
-RUN jq '. + {model: "claude-opus-4-8"}' /home/sclaw/.claude/settings.json > /tmp/settings.json.tmp && \
+RUN jq '. + {model: "claude-opus-5"}' /home/sclaw/.claude/settings.json > /tmp/settings.json.tmp && \
     mv /tmp/settings.json.tmp /home/sclaw/.claude/settings.json
 
 # Shell aliases and shortcuts

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Opens at http://localhost:7680 with:
 
 - Ubuntu 24.04
 - Node.js 24 (LTS)
-- Claude Code 2.1.201
+- Claude Code 2.1.219
 - GitHub CLI with auto-configured git user
 - Playwright MCP with Chromium
 - Slack read-only skill and tool (optional - requires token)
@@ -69,7 +69,7 @@ Opens at http://localhost:7680 with:
 
 ## Sensible defaults
 
-- Claude Code version pinned (currently 2.1.201)
+- Claude Code version pinned (currently 2.1.219)
 - `autoCompactEnabled: false` - prevents automatic context compaction
 - `promptSuggestionEnabled: false` - disables prompt suggestions
 - `--dangerously-skip-permissions` enabled (because it's containerized)


### PR DESCRIPTION
**Version** `2.1.201` → `2.1.219`. 2.1.201 carries a per-turn CPU/memory regression (context indicator re-analyzing the whole transcript every turn) and a 15-20s macOS stall opening background agent sessions, both fixed in 2.1.203.

**Model** `claude-opus-4-8` → `claude-opus-5`, the new default Opus as of 2.1.219.

These go together on purpose: Opus 5 is server-side and already responds on 2.1.201, but the old client caps it at 200k. Confirmed on the host - `contextWindow` went 200000 → 1000000 across the update. Bumping only the model would have given the container a 200k Opus 5.

Verified the pin resolves via the Dockerfile's exact install path in a clean `ubuntu:noble` container. I didn't run a full build, so the model row is worth a look on first boot (CLAUDE.md step 2 updated to say Opus 5).